### PR TITLE
fix: `import/namespace` error

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -1,0 +1,22 @@
+name: Restore Node.js env
+
+description: Restore the task runner infrastructure by Node.js
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ./.node-version
+
+    - name: cache node_modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./node_modules
+        key: node-${{ hashFiles('**/package-lock.json') }}
+
+    - name: install node_modules
+      shell: bash
+      run: npm install

--- a/.github/workflows/check_syntax.yml
+++ b/.github/workflows/check_syntax.yml
@@ -1,0 +1,18 @@
+name: Check Syntax
+
+on:
+  pull_request_target:
+    branches:
+      - '*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize
+        uses: ./.github/actions/restore-node
+
+      - name: Run Lint
+        run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+// @ts-check
+import { essentials, node } from './configs/index.js';
+
+export default [
+  {
+    files: ['**/*.js'],
+  },
+
+  ...essentials,
+  {
+    rules: {
+      'import/no-default-export': ['off'],
+    },
+  },
+
+  ...node,
+];

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "rules"
   ],
   "scripts": {
+    "lint": "eslint './**/*.js'",
     "release": "semantic-release"
   },
   "repository": {

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -24,7 +24,7 @@ export default {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.mjs', '.js', '.json'],
+        extensions: ['.mjs', '.js', '.json', '.ts'],
       },
       // Resolve the problem of incorrect recognition of alias paths by TypeScript compiler options.
       // https://github.com/import-js/eslint-plugin-import/issues/1485#issuecomment-535351922
@@ -36,6 +36,11 @@ export default {
       'node_modules',
       '\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$',
     ],
+    // TODO: Remove this once eslint-plugin-import supports Flat Config completely.
+    // https://github.com/import-js/eslint-plugin-import/issues/2556#issuecomment-1419518561
+    'import/parsers': {
+      espree: ['.js', '.mjs', '.jsx', 'ts', 'tsx'],
+    },
   },
 
   rules: {


### PR DESCRIPTION
## Describe your changes

Flat Config support for `eslint-plugin-import` is not yet complete, which may cause `import/namespace` errors. A fix has been added to resolve this issue.

Also implemented the CI system that works Linter on the source code.

## Issue ticket number and link

- [[Feature Request] Support new ESLint flat config · Issue #2556 · import-js/eslint-plugin-import](https://github.com/import-js/eslint-plugin-import/issues/2556#issuecomment-1419518561)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
