### PR TITLE
ci: Allow exclamation mark alias to be used as `BREAKING CHANGE` keyword

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -3,8 +3,24 @@
  */
 export default {
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        parserOpts: {
+          // see: https://github.com/semantic-release/commit-analyzer/issues/231#issuecomment-1242113093
+          breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+        },
+      },
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        parserOpts: {
+          // see: https://github.com/semantic-release/commit-analyzer/issues/231#issuecomment-1242113093
+          breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+        },
+      },
+    ],
     '@semantic-release/changelog',
     '@semantic-release/npm',
     [


### PR DESCRIPTION
## Describe your changes

Allow `!` to be used as `BREAKING CHANGE` syntax in semantic-release.

As mentioned in the comment below, I tried using `conventionalcommits`, but didn't solve the problem:
https://github.com/semantic-release/commit-analyzer/issues/231#issuecomment-1238670901

As a workaround, I adopted the method mentioned in the comment below:
https://github.com/semantic-release/commit-analyzer/issues/231#issuecomment-1242113093

## Issue ticket number and link

- https://github.com/semantic-release/commit-analyzer/issues/231#issuecomment-1242113093

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
