### PR TITLE
fix: TypeScript import and export parsing

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -13,6 +13,12 @@ export default [
       },
     },
 
+    settings: {
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx', '.cts', '.mts'],
+      },
+    },
+
     ...typescriptRuleSet,
   },
 ];

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -39,7 +39,7 @@ export default {
     // TODO: Remove this once eslint-plugin-import supports Flat Config completely.
     // https://github.com/import-js/eslint-plugin-import/issues/2556#issuecomment-1419518561
     'import/parsers': {
-      espree: ['.js', '.mjs', '.jsx', '.ts', '.mts', '.tsx'],
+      espree: ['.js', '.cjs', '.mjs', '.jsx'],
     },
   },
 

--- a/test/node/__snapshots__/snapshot.test.ts.snap
+++ b/test/node/__snapshots__/snapshot.test.ts.snap
@@ -1950,11 +1950,9 @@ exports[`should match ESLint Configuration snapshot: node 1`] = `
     "import/parsers": {
       "espree": [
         ".js",
+        ".cjs",
         ".mjs",
         ".jsx",
-        ".ts",
-        ".mts",
-        ".tsx",
       ],
     },
     "import/resolver": {

--- a/test/react/__snapshots__/snapshot.test.ts.snap
+++ b/test/react/__snapshots__/snapshot.test.ts.snap
@@ -793,11 +793,17 @@ exports[`should match ESLint Configuration snapshot: react 1`] = `
         ],
       },
     ],
+    "jsdoc/check-template-names": [
+      0,
+    ],
     "jsdoc/check-types": [
       2,
     ],
     "jsdoc/check-values": [
       2,
+    ],
+    "jsdoc/convert-to-jsdoc-comments": [
+      0,
     ],
     "jsdoc/empty-tags": [
       2,
@@ -809,6 +815,9 @@ exports[`should match ESLint Configuration snapshot: react 1`] = `
       0,
     ],
     "jsdoc/informative-docs": [
+      0,
+    ],
+    "jsdoc/lines-before-block": [
       0,
     ],
     "jsdoc/match-description": [
@@ -957,6 +966,9 @@ exports[`should match ESLint Configuration snapshot: react 1`] = `
       2,
     ],
     "jsdoc/require-returns-type": [
+      0,
+    ],
+    "jsdoc/require-template": [
       0,
     ],
     "jsdoc/require-throws": [
@@ -3156,13 +3168,17 @@ exports[`should match ESLint Configuration snapshot: react 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
+        ".cjs",
         ".mjs",
         ".jsx",
-        ".ts",
-        ".mts",
-        ".tsx",
       ],
     },
     "import/resolver": {

--- a/test/storybook/__snapshots__/snapshot.test.ts.snap
+++ b/test/storybook/__snapshots__/snapshot.test.ts.snap
@@ -2958,13 +2958,17 @@ exports[`should match ESLint Configuration snapshot: storybook 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
+        ".cjs",
         ".mjs",
         ".jsx",
-        ".ts",
-        ".mts",
-        ".tsx",
       ],
     },
     "import/resolver": {

--- a/test/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/test/__snapshots__/snapshot.test.ts.snap
@@ -2355,13 +2355,17 @@ exports[`should match ESLint Configuration snapshot: test 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
+        ".cjs",
         ".mjs",
         ".jsx",
-        ".ts",
-        ".mts",
-        ".tsx",
       ],
     },
     "import/resolver": {


### PR DESCRIPTION
## Describe your changes

The parsing settings for `import` and `export` in TypeScript were insufficient, so this bug will be fixed. Without this setting, `import * from` and `export * from` cannot be parsed properly.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
