### PR TITLE
ci: Replace the value of GITHUB_TOKEN from PAT to the one GitHub App generated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -35,5 +42,5 @@ jobs:
       - name: Release
         run: npm run release ${{ github.event.inputs.dry_run == 'true' && '-- --dry-run' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_SEMANTIC_RELEASE }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Describe your changes

The `GITHUB_TOKEN` value referenced by semantic-release was replaced from PAT to the one GitHub App generated.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
